### PR TITLE
Fix `multi-chain-value` tests

### DIFF
--- a/examples/multi-chain-value/lib/MultiChainValue.helpers.ts
+++ b/examples/multi-chain-value/lib/MultiChainValue.helpers.ts
@@ -73,7 +73,7 @@ export const deployZetaMPIMock = async () => {
 };
 
 export const deployZetaEthMock = async () => {
-  const Factory = (await ethers.getContractFactory("ZetaEthMock")) as ZetaEth__factory;
+  const Factory = (await ethers.getContractFactory("ZetaEth")) as ZetaEth__factory;
 
   const zetaMPIMockContract = (await Factory.deploy(100_000)) as ZetaEth;
 

--- a/examples/multi-chain-value/test/MultiChainValue.spec.ts
+++ b/examples/multi-chain-value/test/MultiChainValue.spec.ts
@@ -100,7 +100,8 @@ describe("MultiChainValue tests", () => {
     describe("Given a valid input", () => {
       it("Should send value", async () => {
         await (await multiChainValueContractA.addAvailableChainId(1)).wait();
-
+        
+        await zetaEthMockContract.approve(multiChainValueContractA.address, 100_000);
         await multiChainValueContractA.send(1, account1Address, 100_000);
 
         /**


### PR DESCRIPTION
First error:

```
  1) MultiChainValue tests
       "before each" hook for "Should prevent enabling a chainId that's already enabled":
     HardhatError: HH700: Artifact for contract "ZetaEthMock" not found. Did you mean "ZetaMPIMock"?
      at Artifacts._handleWrongArtifactForContractName (/Users/pavel/sandbox/zeta-examples/node_modules/hardhat/src/internal/artifacts.ts:478:11)
      at Artifacts._getArtifactPathFromFiles (/Users/pavel/sandbox/zeta-examples/node_modules/hardhat/src/internal/artifacts.ts:592:19)
      at Artifacts._getArtifactPath (/Users/pavel/sandbox/zeta-examples/node_modules/hardhat/src/internal/artifacts.ts:275:17)
      at async Artifacts.readArtifact (/Users/pavel/sandbox/zeta-examples/node_modules/hardhat/src/internal/artifacts.ts:58:26)
      at async getContractFactory (/Users/pavel/sandbox/zeta-examples/node_modules/@nomiclabs/hardhat-ethers/src/internal/helpers.ts:91:22)
      at async deployZetaEthMock (lib/MultiChainValue.helpers.ts:76:20)
      at async Context.<anonymous> (test/MultiChainValue.spec.ts:23:27)
```

Second error:

```
  1) MultiChainValue tests
       send
         Given a valid input
           Should send value:
     Error: VM Exception while processing transaction: reverted with reason string 'ERC20: insufficient allowance'
    at ZetaEth._spendAllowance (@openzeppelin/contracts/token/ERC20/ERC20.sol:337)
    at ZetaEth.transferFrom (@openzeppelin/contracts/token/ERC20/ERC20.sol:164)
    at MultiChainValueMock.send (contracts/MultiChainValue.sol:42)
    at async HardhatNode._mineBlockWithPendingTxs (/Users/pavel/sandbox/zeta-examples/node_modules/hardhat/src/internal/hardhat-network/provider/node.ts:1772:23)
    at async HardhatNode.mineBlock (/Users/pavel/sandbox/zeta-examples/node_modules/hardhat/src/internal/hardhat-network/provider/node.ts:466:16)
    at async EthModule._sendTransactionAndReturnHash (/Users/pavel/sandbox/zeta-examples/node_modules/hardhat/src/internal/hardhat-network/provider/modules/eth.ts:1496:18)
    at async HardhatNetworkProvider.request (/Users/pavel/sandbox/zeta-examples/node_modules/hardhat/src/internal/hardhat-network/provider/provider.ts:118:18)
    at async EthersProviderWrapper.send (/Users/pavel/sandbox/zeta-examples/node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)
```